### PR TITLE
 spelling correction - README.MD

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ NATO::Text.new("bzt").say # pipes out to "say" on mac or "espeak" on linux
 ### CLI
 
 ```bash
-$ gem install nato
+$ gem install NATO
 $ nato --convert "bctz" # Bravo Charlie Tango Zulu
 $ nato --say "bctz" # uses system text-to-speech tool
 ```


### PR DESCRIPTION
should be NATO instead of nato, otherwise get error
ERROR:  Could not find a valid gem 'nato' (>= 0) in any repository
ERROR:  Possible alternatives: NATO